### PR TITLE
FIX: Multiple issues fixed

### DIFF
--- a/listo.h
+++ b/listo.h
@@ -34,10 +34,12 @@ struct Editors edt[] = {
 static FILE *xopen(const char *filename, const char *modes)
 {
     FILE *fp = fopen(filename, modes);
+    char err_msg[128] = { '\0' };
 
     if (fp == NULL) {
-        perror("fopen()");
-        return NULL;
+        sprintf(err_msg, "fopen(): %s", filename);
+        perror(err_msg);
+        exit(EXIT_FAILURE);
     }
 
     return fp;


### PR DESCRIPTION
Hi @rilysh 👋

This fixes a couple of issues with the code. Mainly, error handling:

* Added terminating NULL to args array preventing execv() from aborting.
* Added error checking in multiple places: open_with_editor(), print_all_lists(), xopen()

Changes tested under Debian 11 (amd64) with GCC 10.2.1 20210110.